### PR TITLE
Refactor writeBytes to support writing in chunks; Use OSError code as PortError rawValue

### DIFF
--- a/Sources/SerialTerminal/Terminal.swift
+++ b/Sources/SerialTerminal/Terminal.swift
@@ -10,8 +10,9 @@ struct Terminal: AsyncParsableCommand {
 	var path: String
 
 	@Argument(help: "Baud Rate", transform: {
-		let value = UInt($0) ?? 1
-		return try BaudRate(value)
+        return try BaudRate(UInt($0) ?? 1) ?? {
+            throw ValidationError("Invalid Baud Rate value")
+        }()
 	})
 	var baudRate: BaudRate
 

--- a/Sources/SwiftSerial/BaudRate.swift
+++ b/Sources/SwiftSerial/BaudRate.swift
@@ -34,7 +34,7 @@ public enum BaudRate {
 	case baud4000000
 	#endif
 
-	public init(_ value: UInt) throws {
+	public init?(_ value: UInt) {
 		switch value {
 		case 0:
 			self = .baud0
@@ -99,7 +99,7 @@ public enum BaudRate {
 			self = .baud4000000
 		#endif
 		default:
-			throw PortError.invalidPort
+			return nil
 		}
 	}
 

--- a/Sources/SwiftSerial/PortError.swift
+++ b/Sources/SwiftSerial/PortError.swift
@@ -6,6 +6,8 @@ public struct PortError: RawRepresentable, Error, LocalizedError {
         case mustBeOpen = 0
         case instanceAlreadyOpen = -1
 
+        case unableToConvertByteToCharacter = -997
+        case stringsMustBeUTF8 = -998
         case internalInconsistency = -999
     }
 
@@ -14,6 +16,9 @@ public struct PortError: RawRepresentable, Error, LocalizedError {
 
     static let invalidPath = PortError(rawValue: ENOENT)
     static let timeout = PortError(rawValue: ETIMEDOUT)
+
+    static let stringsMustBeUTF8 = PortError(rawValue: SwiftSerialError.stringsMustBeUTF8.rawValue)
+    static let unableToConvertByteToCharacter = PortError(rawValue: SwiftSerialError.unableToConvertByteToCharacter.rawValue)
 
     static let internalInconsistency = PortError(rawValue: SwiftSerialError.internalInconsistency.rawValue)
 
@@ -30,8 +35,14 @@ public struct PortError: RawRepresentable, Error, LocalizedError {
         case .mustBeOpen:
             return "SerialPort must be open"
 
+        case .unableToConvertByteToCharacter:
+            return "unable to convert byte to character"
+        case .stringsMustBeUTF8:
+            return "Strings must be in UTF-8 encoding"
+
         case .internalInconsistency:
             return "Internal inconsistency"
+
         case .none:
             return String(cString: strerror(rawValue))
         }

--- a/Sources/SwiftSerial/PortError.swift
+++ b/Sources/SwiftSerial/PortError.swift
@@ -1,13 +1,40 @@
 import Foundation
 
-public enum PortError: Int32, Error {
-	case failedToOpen = -1 // refer to open()
-	case invalidPath
-	case mustReceiveOrTransmit
-	case mustBeOpen
-	case stringsMustBeUTF8
-	case unableToConvertByteToCharacter
-	case deviceNotConnected
-	case instanceAlreadyOpen
-	case invalidPort
+public struct PortError: RawRepresentable, Error, LocalizedError {
+
+    public enum SwiftSerialError: Int32 {
+        case mustBeOpen = 0
+        case instanceAlreadyOpen = -1
+
+        case internalInconsistency = -999
+    }
+
+    static let instanceAlreadyOpen = PortError(rawValue: SwiftSerialError.instanceAlreadyOpen.rawValue)
+    static let mustBeOpen = PortError(rawValue: SwiftSerialError.mustBeOpen.rawValue)
+
+    static let invalidPath = PortError(rawValue: ENOENT)
+    static let timeout = PortError(rawValue: ETIMEDOUT)
+
+    static let internalInconsistency = PortError(rawValue: SwiftSerialError.internalInconsistency.rawValue)
+
+    public let rawValue: Int32
+
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    public var errorDescription: String? {
+        switch SwiftSerialError(rawValue: rawValue) {
+        case .instanceAlreadyOpen:
+            return "SerialPort is already open"
+        case .mustBeOpen:
+            return "SerialPort must be open"
+
+        case .internalInconsistency:
+            return "Internal inconsistency"
+        case .none:
+            return String(cString: strerror(rawValue))
+        }
+    }
+
 }

--- a/Sources/SwiftSerial/PortMode.swift
+++ b/Sources/SwiftSerial/PortMode.swift
@@ -1,29 +1,52 @@
+#if canImport(Darwin)
+import Darwin
+#endif
 import Foundation
 
-public enum PortMode {
-	case receive
-	case transmit
-	case receiveAndTransmit
+public struct PortMode: RawRepresentable, OptionSet {
 
-	var receive: Bool {
-		switch self {
-		case .receive:
-			true
-		case .transmit:
-			false
-		case .receiveAndTransmit:
-			true
-		}
-	}
+    public let rawValue: Int32
 
-	var transmit: Bool {
-		switch self {
-		case .receive:
-			false
-		case .transmit:
-			true
-		case .receiveAndTransmit:
-			true
-		}
-	}
+    /// Can be initialized
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    /// open for reading only
+    public static let readOnly = PortMode(rawValue: O_RDONLY)
+    /// open for writing only
+    public static let writeOnly = PortMode(rawValue: O_WRONLY)
+    /// open for reading and writing
+    public static let readWrite = PortMode(rawValue: O_RDWR)
+    /// don't assign controlling terminal
+    public static let noControllingTerminal = PortMode(rawValue: O_NOCTTY)
+
+    /// no delay
+    public static let nonBlocking = PortMode(rawValue: O_NONBLOCK)
+    /// set append mode
+    public static let append = PortMode(rawValue: O_APPEND)
+
+    /// open with shared file lock
+    public static let sharedLock = PortMode(rawValue: O_SHLOCK)
+    /// open with exclusive file lock
+    public static let exclusiveLock = PortMode(rawValue: O_EXLOCK)
+    /// signal pgrp when data ready
+    public static let async = PortMode(rawValue: O_ASYNC)
+    /// synch I/O file integrity
+    public static let sync = PortMode(rawValue: O_SYNC)
+
+    /// implicitly set FD_CLOEXEC (close-on-exec flag)
+    public static let closeOnExec = PortMode(rawValue: O_CLOEXEC)
+
+    // default OS-specific configurations
+#if os(Linux)
+    public static let receive = PortMode(rawValue: O_RDONLY | O_NOCTTY)
+    public static let transmit = PortMode(rawValue: O_WRONLY | O_NOCTTY)
+    public static let receiveAndTransmit = PortMode(rawValue: O_RDWR | O_NOCTTY)
+#elseif os(OSX)
+    public static let receive = PortMode(rawValue: O_RDONLY | O_NOCTTY | O_EXLOCK)
+    public static let transmit = PortMode(rawValue: O_WRONLY | O_NOCTTY | O_EXLOCK)
+    public static let receiveAndTransmit = PortMode(rawValue: O_RDWR | O_NOCTTY | O_EXLOCK)
+#endif
+
 }

--- a/Sources/SwiftSerial/SerialPort.swift
+++ b/Sources/SwiftSerial/SerialPort.swift
@@ -375,10 +375,9 @@ extension SerialPort {
 		return bytesWritten
 	}
 
-    public func writeString(_ string: String, encoding: String.Encoding = .utf8) throws -> Int {
-        guard let data = string.data(using: encoding) else {
-            throw CocoaError(.fileWriteInapplicableStringEncoding, userInfo: [NSStringEncodingErrorKey: encoding.rawValue])
-		}
+    public func writeString(_ string: String) throws -> Int {
+        // Valid String is always convertible to UTF-8
+        let data = string.data(using: .utf8)!
 
 		return try writeData(data)
 	}

--- a/Sources/SwiftSerial/SerialPortDeprecated.swift
+++ b/Sources/SwiftSerial/SerialPortDeprecated.swift
@@ -109,7 +109,7 @@ extension SerialPort {
 
 			if bytesRead > 0 {
 				if ( buffer[0] > 127) {
-                    throw CocoaError(.fileReadUnknownStringEncoding, userInfo: [NSStringEncodingErrorKey: String.Encoding.ascii.rawValue])
+					throw PortError.unableToConvertByteToCharacter
 				}
 				let character = CChar(buffer[0])
 
@@ -124,7 +124,7 @@ extension SerialPort {
 		if let string = String(data: data, encoding: String.Encoding.utf8) {
 			return string
 		} else {
-            throw CocoaError(.fileReadUnknownStringEncoding, userInfo: [NSStringEncodingErrorKey: String.Encoding.utf8.rawValue])
+			throw PortError.stringsMustBeUTF8
 		}
 	}
 


### PR DESCRIPTION
- Added support to provide custom `open` flags by `rawValue`, added more `PortMode` options
- Refactored `writeBytes` procedure to wait for file descriptor to become ready to write and to write data in chunks to support sending long messages (inspired by https://github.com/wjwwood/serial/blob/main/src/impl/unix.cc)
- Refactored `PortError` to use actual `OSError` under the hood and provide localized description
- Added some docs